### PR TITLE
[Bug Fix] Add missing bias in HeadwiseLowRankModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pip install -e 3rdparty/fast-hadamard-transform
 We provide a script `compress.py` to perform the rank search and low-rank decomposition to generate the low-rank projection matrices for compressing KV-Cache. Here, we perform the decomposition with proposed `G-LRD` methods with group size equal to 4 as an example. 
 ```bash
 python compress.py \
---model_id="meta-llama/Llama-2-7b-hf" \
+--model_id=/Path/To/Pretrained/Model \
 --calib_dataset wikitext2 \
 --param_ratio_target 0.7 \
 --search_method fisher_uniform \
@@ -58,7 +58,7 @@ python compress.py \
 --use_cache 
 ```
 
-After executing the above command, a compressed models with decomposed low-rank projection matrices will be dumped into the `Llama-2-7b-hf_ratio-0.5_gs-4-fisher_uniform` directory. Here, the dumped models is stored via the huggingface transformers format. 
+After executing the above command, a compressed models with decomposed low-rank projection matrices will be dumped into the `{MODEL_NAME}-ratio-{TARGET_RATIO}_gs-{GROUP_SIZE}-{SEARCH_METHOD}-{DECOMPOSE_METHODS}` directory. Here, the dumped models is stored via the huggingface transformers format. 
 
 ### Evaluation
 With the compressed model dumped, we can evaluate the performance of the compressed model on the various tasks. We provide the scripts for evaluating the perplexity, zero-shot evaluation, and LongBench. By default, we will keep the compressed KV-Cache in fp16.
@@ -93,7 +93,7 @@ Before we start, please make sure the `lm-eval==0.4.2` library is installed.
 
 To reproduce the results in our paper, simply execute:
 ```bash 
-CUDA_VISIBLE_DEVICES=0 python run_lm_eval.py --model_name_or_path "./Meta-Llama-3-8b-Instruct_ratio-0.7_gs-4-fisher_uniform" \
+CUDA_VISIBLE_DEVICES=0 python run_lm_eval.py --model_name_or_path /Path/To/Palu/Model \
 --tasks "openbookqa,hellaswag,piqa,arc_easy,arc_challenge,winogrande"
 ```
 

--- a/palu/model/__init__.py
+++ b/palu/model/__init__.py
@@ -9,6 +9,13 @@ from .svd_mistral import (
     PaluMistralConfig,
     PaluMistralForCausalLM
 )
+
+#qwen
+from .svd_qwen import (
+    PaluQwen2Config,
+    PaluQwen2ForCausalLM
+)
+
 #modules
 from .modules import (
     HeadwiseLowRankModule
@@ -26,5 +33,9 @@ AVAILABLE_MODELS = {
     'mistral': {
         'config': PaluMistralConfig,
         'ModelForCausalLM': PaluMistralForCausalLM
+    },
+    'qwen2': {
+        'config': PaluQwen2Config,
+        'ModelForCausalLM': PaluQwen2ForCausalLM
     }
 }

--- a/palu/model/svd_qwen/__init__.py
+++ b/palu/model/svd_qwen/__init__.py
@@ -1,0 +1,8 @@
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, Qwen2Tokenizer
+from .configuration_palu_qwen import PaluQwen2Config
+from .modeling_palu_qwen import PaluQwen2ForCausalLM
+
+AutoConfig.register("paluqwen2", PaluQwen2Config)
+AutoModelForCausalLM.register(PaluQwen2Config, PaluQwen2ForCausalLM)
+AutoTokenizer.register(PaluQwen2Config, Qwen2Tokenizer)
+

--- a/palu/model/svd_qwen/configuration_palu_qwen.py
+++ b/palu/model/svd_qwen/configuration_palu_qwen.py
@@ -1,0 +1,61 @@
+from transformers.configuration_utils import PretrainedConfig
+from transformers.utils import logging
+
+logger = logging.get_logger(__name__)
+
+class PaluQwen2Config(PretrainedConfig):
+    model_type = "paluqwen2"
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        vocab_size=151936,
+        hidden_size=4096,
+        intermediate_size=22016,
+        num_hidden_layers=32,
+        num_attention_heads=32,
+        num_key_value_heads=32,
+        hidden_act="silu",
+        max_position_embeddings=32768,
+        initializer_range=0.02,
+        rms_norm_eps=1e-6,
+        use_cache=True,
+        tie_word_embeddings=False,
+        rope_theta=10000.0,
+        use_sliding_window=False,
+        sliding_window=4096,
+        max_window_layers=28,
+        attention_dropout=0.0,
+        # [Palu]
+        head_wise_ranks=None,
+        **kwargs,
+    ):
+        self.vocab_size = vocab_size
+        self.max_position_embeddings = max_position_embeddings
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.use_sliding_window = use_sliding_window
+        self.sliding_window = sliding_window if use_sliding_window else None
+        self.max_window_layers = max_window_layers
+
+        # for backward compatibility
+        if num_key_value_heads is None:
+            num_key_value_heads = num_attention_heads
+
+        self.num_key_value_heads = num_key_value_heads
+        self.hidden_act = hidden_act
+        self.initializer_range = initializer_range
+        self.rms_norm_eps = rms_norm_eps
+        self.use_cache = use_cache
+        self.rope_theta = rope_theta
+        self.attention_dropout = attention_dropout
+
+        super().__init__(
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )
+
+        # for avsd
+        self.head_wise_ranks = head_wise_ranks

--- a/palu/model/svd_qwen/modeling_palu_qwen.py
+++ b/palu/model/svd_qwen/modeling_palu_qwen.py
@@ -1,0 +1,64 @@
+from transformers import Qwen2ForCausalLM
+import torch.nn as nn
+from types import SimpleNamespace
+from .configuration_palu_qwen import PaluQwen2Config
+from ..modules.svd_linear import HeadwiseLowRankModule
+
+class PaluQwen2ForCausalLM(Qwen2ForCausalLM):
+    config_class = PaluQwen2Config
+    def __init__(self, config: PaluQwen2Config):
+        super().__init__(config)
+        self.head_wise_ranks=config.head_wise_ranks
+
+        full_name_dict = {module: name for name, module in self.named_modules()}
+        linear_info = {}
+        modules = [self]
+        while len(modules) > 0:
+            submodule = modules.pop()
+            for name, raw_linear in submodule.named_children():
+                if isinstance(raw_linear, nn.Linear):
+                    full_name = full_name_dict[raw_linear]
+                    linear_info[raw_linear] = {
+                        "father": submodule,
+                        "name": name,
+                        "full_name": full_name,
+                    }
+                else:
+                    modules.append(raw_linear)
+
+
+        for name, module in self.named_modules():
+            if name in self.head_wise_ranks:
+                info = linear_info[module]
+                new_layer = HeadwiseLowRankModule(
+                    self.head_wise_ranks[name],
+                    module.in_features,
+                    module.out_features,
+                    bias=module.bias is not None
+                )
+                setattr(info["father"], info["name"], new_layer)
+    
+    
+    @staticmethod
+    def get_kv_info(qwen2: Qwen2ForCausalLM, num_heads_in_lr_groups: int):
+        num_lr_groups = qwen2.config.num_attention_heads // num_heads_in_lr_groups
+        num_lr_kv_groups = qwen2.config.num_key_value_heads // num_heads_in_lr_groups
+        head_dim = qwen2.config.hidden_size // qwen2.config.num_attention_heads
+        lr_group_dims = head_dim * num_heads_in_lr_groups
+        
+        if num_lr_groups * num_heads_in_lr_groups != qwen2.config.num_attention_heads:
+            raise ValueError(
+                f"num_heads must be divisible by num_heads_in_lr_groups (got `num_heads`: {qwen2.config.num_attention_heads}"
+                f" and `num_heads_in_lr_groups`: {num_heads_in_lr_groups})."
+            )
+    
+        if num_lr_kv_groups * num_heads_in_lr_groups != qwen2.config.num_key_value_heads:
+            raise ValueError(
+                f"num_key_value_heads must be divisible by num_heads_in_lr_groups (got `num_key_value_heads`: {qwen2.config.num_key_value_heads}"
+                f" and `num_heads_in_lr_groups`: {num_heads_in_lr_groups})."
+            )
+
+        return SimpleNamespace(
+            num_lr_groups=num_lr_kv_groups,
+            lr_group_dims=lr_group_dims,
+        )

--- a/palu/rank_search.py
+++ b/palu/rank_search.py
@@ -89,7 +89,7 @@ def rank_search(model: nn.Module, tokenizer, args):
         target_model_class = AVAILABLE_MODELS[model.config.model_type]["ModelForCausalLM"]
         total_rank = 0
         select_result = {}
-        info = target_model_class.get_info(model, args.head_group_size)
+        info = target_model_class.get_kv_info(model, args.head_group_size)
         
         for name, module in model.named_modules():
             if "k_proj" in name or "v_proj" in name:                

--- a/utils.py
+++ b/utils.py
@@ -64,6 +64,9 @@ def dump_to_huggingface_repos(model, tokenizer, save_path, args):
     elif "mistral" in model.config._name_or_path.lower():
         config["model_type"] = "palumistral"
         config['architectures'] = ['PaluMistralForCausalLM']
+    elif "qwen2" in model.config._name_or_path.lower():
+        config["model_type"] = "paluqwen2"
+        config['architectures'] = ['PaluQwenForCausalLM']
     else:
         raise NotImplementedError
             


### PR DESCRIPTION
# Description
In some models, the `k_proj` and `v_proj` layers come with a bias. In the previous implementation, we missed the bias term when we translated `nn.Linear` to `HeadwiseLowRankModule` for simulating accuracy.

## Change in this PR
+ Fix missing bias in `HeadwiseLowRankModule`
+ Support Qwen2.
+ Add interface for use to specify different matrix decomposition algorithms. 


